### PR TITLE
Feature/remember selected tenancy

### DIFF
--- a/ng-ncc-app/src/app/components/address-tenants-results/address-tenants-results.component.html
+++ b/ng-ncc-app/src/app/components/address-tenants-results/address-tenants-results.component.html
@@ -3,7 +3,7 @@
 <div class="govuk-body" *ngIf="hasResults()">
 
     <!-- Go back to the address results. -->
-    <button type="button" class="link-button" (click)="goBack()">
+    <button type="button" class="link-button" (click)="goBack()" *ngIf="showBackButton">
         Back to address results
     </button>
 

--- a/ng-ncc-app/src/app/components/address-tenants-results/address-tenants-results.component.ts
+++ b/ng-ncc-app/src/app/components/address-tenants-results/address-tenants-results.component.ts
@@ -10,6 +10,7 @@ import { IdentifiedCaller } from '../../classes/identified-caller.class';
 })
 export class AddressTenantsResultsComponent implements OnChanges {
     @Input() address: AddressSearchGroupedResult;
+    @Input() showBackButton: boolean;
 
     // When a tenant is selected and the Continue button is hit.
     @Output() selected = new EventEmitter<IdentifiedCaller>();

--- a/ng-ncc-app/src/app/components/call-nature/call-nature.component.ts
+++ b/ng-ncc-app/src/app/components/call-nature/call-nature.component.ts
@@ -12,7 +12,7 @@ import { LogCallType } from '../../classes/log-call-type.class';
     templateUrl: './call-nature.component.html',
     styleUrls: ['./call-nature.component.scss']
 })
-export class CallNatureComponent implements OnInit {
+export class CallNatureComponent implements OnInit, OnDestroy {
     @Output() changed = new EventEmitter<LogCallSelection>();
 
     private _destroyed$ = new Subject();

--- a/ng-ncc-app/src/app/pages/identify/identify.component.html
+++ b/ng-ncc-app/src/app/pages/identify/identify.component.html
@@ -1,46 +1,50 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <!-- Search for contact details. -->
-        <h2 class="govuk-heading-l">Caller details</h2>
+        <div *ngIf="!existing_call">
 
-        <!-- Search box - see https://github.com/alphagov/govuk-design-system-backlog/issues/132 -->
-        <app-panel class="govuk-!-margin-bottom-5">
-            <form action="">
-                <div class="govuk-form-group govuk-!-margin-bottom-2">
-                    <label class="govuk-label govuk-!-font-weight-bold" for="query">
-                        Search by postcode:
-                    </label>
-                    <input class="govuk-input govuk-!-width-one-half govuk-!-margin-right-1" id="query" name="query" type="text" [(ngModel)]="postcode" [disabled]="_searching">
-                    <button type="submit" class="govuk-button govuk-!-margin-bottom-0" (click)="performSearch()" [disabled]="!canPerformSearch()">
-                        Search
-                    </button>
-                </div>
-            </form>
-        </app-panel>
+            <!-- Search for contact details. -->
+            <h2 class="govuk-heading-l">Caller details</h2>
 
-        <!-- Or... -->
-        <app-or></app-or>
+            <!-- Search box - see https://github.com/alphagov/govuk-design-system-backlog/issues/132 -->
+            <app-panel class="govuk-!-margin-bottom-5">
+                <form action="">
+                    <div class="govuk-form-group govuk-!-margin-bottom-2">
+                        <label class="govuk-label govuk-!-font-weight-bold" for="query">
+                            Search by postcode:
+                        </label>
+                        <input class="govuk-input govuk-!-width-one-half govuk-!-margin-right-1" id="query" name="query" type="text" [(ngModel)]="postcode" [disabled]="_searching">
+                        <button type="submit" class="govuk-button govuk-!-margin-bottom-0" (click)="performSearch()" [disabled]="!canPerformSearch()">
+                            Search
+                        </button>
+                    </div>
+                </form>
+            </app-panel>
 
-        <!-- Option to mark the caller as anonymous. -->
-        <p class="govuk-body">
-            <button class="link-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" (click)="anonymousSelected()">
-                Caller is anonymous
-            </button>
-            <app-helper>
-                Select this option if the caller wants to remain anonymous.<br>
-                Anonymous callers will not be able to access sensitive information.
-            </app-helper>
-        </p>
+            <!-- Or... -->
+            <app-or></app-or>
 
-        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+            <!-- Option to mark the caller as anonymous. -->
+            <p class="govuk-body">
+                <button class="link-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" (click)="anonymousSelected()">
+                    Caller is anonymous
+                </button>
+                <app-helper>
+                    Select this option if the caller wants to remain anonymous.<br>
+                    Anonymous callers will not be able to access sensitive information.
+                </app-helper>
+            </p>
 
-        <!-- A list of addresses matching the search query. -->
-        <app-address-search-results [results]="results" *ngIf="shouldShowAddresses()"
-            (selected)="addressSelected($event)"></app-address-search-results>
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+            <!-- A list of addresses matching the search query. -->
+            <app-address-search-results [results]="results" *ngIf="shouldShowAddresses()"
+                (selected)="addressSelected($event)"></app-address-search-results>
+        </div>
 
         <!-- A list of tenants at the selected address. -->
         <app-address-tenants-results [address]="selected_address" *ngIf="shouldShowTenants()"
+            [showBackButton]="!existing_call"
             (beginEdit)="tenantToEdit($event)"
             (selected)="tenantSelected($event)"
             (back)="backToAddresses()">

--- a/ng-ncc-app/src/app/pages/identify/identify.component.ts
+++ b/ng-ncc-app/src/app/pages/identify/identify.component.ts
@@ -20,7 +20,9 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
 
     private _destroyed$ = new Subject();
 
-    _searching: boolean;
+
+    existing_call: boolean;
+    searching: boolean;
     postcode: string;
     results: CitizenIndexSearchResult[];
     selected_address: AddressSearchGroupedResult;
@@ -28,7 +30,13 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
     constructor(private router: Router, private HackneyAPI: HackneyAPIService, private Call: CallService) { }
 
     ngOnInit() {
-        this._searching = false;
+        this.searching = false;
+        this.existing_call = false;
+
+        if (this.Call.hasCaller()) {
+            this.existing_call = true;
+            this.addressSelected(this.Call.getTenancy());
+        }
     }
 
     ngOnDestroy() {
@@ -40,12 +48,12 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
      */
     performSearch() {
         // For the time being, we are only searching for people by postcode.
-        if (this._searching) {
+        if (this.searching) {
             return;
         }
         this.results = null;
         this.selected_address = null;
-        this._searching = true;
+        this.searching = true;
 
         const subscription = this.HackneyAPI.getCitizenIndexSearch(null, null, null, this.postcode)
             .pipe(
@@ -59,7 +67,7 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
                     console.error(error);
                 },
                 () => {
-                    this._searching = false;
+                    this.searching = false;
                     subscription.unsubscribe();
                 }
             );
@@ -69,7 +77,7 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
      * Returns TRUE if the user can peform a search for details.
      */
     canPerformSearch() {
-        return !this._searching && !!(this.postcode);
+        return !this.searching && !!(this.postcode);
     }
 
     /**
@@ -136,6 +144,9 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
         this.selected_address = null;
     }
 
+    /**
+     * Navigats to the next step, having selected a tenant (or an anonymous caller).
+     */
     nextStep() {
         if (this.Call.hasCaller()) {
             this.router.navigateByUrl('comms');

--- a/ng-ncc-app/src/app/pages/identify/identify.component.ts
+++ b/ng-ncc-app/src/app/pages/identify/identify.component.ts
@@ -33,7 +33,7 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
         this.searching = false;
         this.existing_call = false;
 
-        if (this.Call.hasCaller()) {
+        if (this.Call.hasTenancy()) {
             this.existing_call = true;
             this.addressSelected(this.Call.getTenancy());
         }

--- a/ng-ncc-app/src/app/services/call.service.ts
+++ b/ng-ncc-app/src/app/services/call.service.ts
@@ -158,6 +158,13 @@ export class CallService {
         this._buildTenantsList();
     }
 
+    /**
+     *
+     */
+    hasTenancy(): boolean {
+        return null !== this.tenancy;
+    }
+
     _buildTenantsList() {
         this.tenants = this.tenancy.results.map((row) => {
             return {


### PR DESCRIPTION
![screenshot - 09_10_2018 11_52_45](https://user-images.githubusercontent.com/41298289/46664862-15820c00-cbba-11e8-9c8b-80aa8b47a7bd.png)

Going back to the Caller Details page when on a call should display a list of tenants at the selected property. This will have no effect for anonymous callers.