### PR TITLE
Placeholders in GOV.UK Notify comms template subjects.

### DIFF
--- a/ng-ncc-app/src/app/API/HackneyAPI/hackney-api.service.ts
+++ b/ng-ncc-app/src/app/API/HackneyAPI/hackney-api.service.ts
@@ -16,6 +16,8 @@ import { ICitizenIndexSearchResult } from '../../interfaces/citizen-index-search
 export class HackneyAPIService {
 
     _url = 'https://sandboxapi.hackney.gov.uk/hackneyapi';
+    // _url = 'https://api.hackney.gov.uk';
+    // TODO configure the host based on the build settings.
 
     constructor(private http: HttpClient) { }
 

--- a/ng-ncc-app/src/app/API/ManageATenancyAPI/manageatenancy-api.service.ts
+++ b/ng-ncc-app/src/app/API/ManageATenancyAPI/manageatenancy-api.service.ts
@@ -21,6 +21,8 @@ export class ManageATenancyAPIService {
     // TODO these API services can extend a general class.
 
     _url = 'https://sandboxapi.hackney.gov.uk/manageatenancy/v1';
+    // _url = 'https://api.hackney.gov.uk/manageatenancy/v1';
+    // TODO configure the host based on the build settings.
 
     constructor(private http: HttpClient) { }
 

--- a/ng-ncc-app/src/app/API/ManageATenancyAPI/manageatenancy-api.service.ts
+++ b/ng-ncc-app/src/app/API/ManageATenancyAPI/manageatenancy-api.service.ts
@@ -31,10 +31,10 @@ export class ManageATenancyAPIService {
         return this.http
             .get(`${this._url}/Accounts/AccountDetailsByContactId?contactid=${crm_contact_id}`)
             .pipe(
-                map((data: IJSONResponse) => {
+                map((data: any) => {
                     // We should have just one result, containing a bunch of information.
                     // TODO how do we handle having no information?
-                    return <IAccountDetails>data.results;
+                    return data.results as IAccountDetails;
                 },
                     (error) => {
                         console.log('Error fetching account details:', error);

--- a/ng-ncc-app/src/app/API/NCCAPI/ncc-api.service.ts
+++ b/ng-ncc-app/src/app/API/NCCAPI/ncc-api.service.ts
@@ -30,6 +30,8 @@ export class NCCAPIService {
     NOTE_TYPE_MANUAL = 2;
 
     _url = 'https://sandboxapi.hackney.gov.uk/lbhnccapi/api/';
+    // _url = 'https://api.hackney.gov.uk/lbhnccapi/api/';
+    // TODO configure the host based on the build settings.
 
     constructor(private http: HttpClient) { }
 

--- a/ng-ncc-app/src/app/API/NotifyAPI/notify-api.service.ts
+++ b/ng-ncc-app/src/app/API/NotifyAPI/notify-api.service.ts
@@ -20,6 +20,8 @@ import { CONTACT } from '../../constants/contact.constant';
 export class NotifyAPIService {
 
     _url = 'https://sandboxapi.hackney.gov.uk/lbhnccapi/api/GovNotifier';
+    // _url = 'https://api.hackney.gov.uk/lbhnccapi/api/GovNotifier';
+    // TODO configure the host based on the build settings.
 
     constructor(private http: HttpClient) { }
 
@@ -67,11 +69,11 @@ export class NotifyAPIService {
     /**
      * Returns a preview of a specified GOV.UK Notify template.
      */
-    getTemplatePreview(template_id: string, version: number = 1) {
+    getTemplatePreview(template_id: string, version: number = 1): Observable<INotifyAPITemplate> {
         return this.http
             .get(`${this._url}/GetTemplateByIdAndVersion?TemplateId=${template_id}&Version=${version}`)
             .pipe(
-                map((data: INotifyAPIJSONResult) => data.response.body)
+                map((data: INotifyAPIJSONResult) => data.response)
             );
     }
 

--- a/ng-ncc-app/src/app/components/last-calls/last-calls.component.ts
+++ b/ng-ncc-app/src/app/components/last-calls/last-calls.component.ts
@@ -40,4 +40,11 @@ export class LastCallsComponent implements OnInit, OnDestroy {
         this._destroyed$.next();
     }
 
+    /**
+     *
+     */
+    trackByIndex(index: number, item: {}): number {
+        return index;
+    }
+
 }

--- a/ng-ncc-app/src/app/components/notify-template-preview/notify-template-preview.component.html
+++ b/ng-ncc-app/src/app/components/notify-template-preview/notify-template-preview.component.html
@@ -2,7 +2,7 @@
     <div class="govuk-grid-column-one-half">
 
         <!-- Preview of the template. -->
-        <app-panel class="govuk-form-group govuk-body">
+        <app-panel class="govuk-form-group govuk-body" *ngIf="preview">
             <span *ngIf="_loading">loading...</span>
             <span *ngIf="!_loading" [innerHTML]="getCustomisedPreview()"></span>
         </app-panel>

--- a/ng-ncc-app/src/app/components/notify-template-preview/notify-template-preview.component.ts
+++ b/ng-ncc-app/src/app/components/notify-template-preview/notify-template-preview.component.ts
@@ -4,6 +4,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import { NotifyAPIService } from '../../API/NotifyAPI/notify-api.service';
 import { ITemplatePreviewSettings } from '../../interfaces/template-preview-settings';
+import { INotifyAPITemplate } from '../../interfaces/notify-api-template';
 
 @Component({
     selector: 'app-notify-template-preview',
@@ -17,13 +18,12 @@ export class NotifyTemplatePreviewComponent implements OnInit, OnChanges, OnDest
     private _destroyed$ = new Subject();
 
     _loading: boolean;
-    preview: string;
+    preview: INotifyAPITemplate;
 
     constructor(private NotifyAPI: NotifyAPIService) { }
 
     ngOnInit() {
         this._loading = false;
-        this.preview = 'testing';
     }
 
     ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
@@ -78,14 +78,27 @@ export class NotifyTemplatePreviewComponent implements OnInit, OnChanges, OnDest
      * Returns a list of labels representing placeholders.
      */
     getPlaceholders(): string[] {
+        // Make sure we have a preview before continuing!
+        if (!this.preview) {
+            return;
+        }
+
         // const regex = new RegExp('\(\(([A-za-z0-9 ]+)\)\)', 'gm');
         const regex = /\(\(([A-za-z0-9 ]+)\)\)/gm;
-        const matches = regex.exec(this.preview);
-        let placeholders: string[];
-        placeholders = [];
-        if (matches) {
-            placeholders.push(matches[1]);
+        const placeholders: string[] = [];
+
+        // Placeholders in the subject.
+        const subject_matches = regex.exec(this.preview.subject);
+        if (subject_matches) {
+            placeholders.push(subject_matches[1]);
         }
+
+        // Placeholders in the body.
+        const body_matches = regex.exec(this.preview.body);
+        if (body_matches) {
+            placeholders.push(body_matches[1]);
+        }
+
         return placeholders;
     }
 
@@ -93,7 +106,7 @@ export class NotifyTemplatePreviewComponent implements OnInit, OnChanges, OnDest
      *
      */
     getCustomisedPreview(): string {
-        let preview = this.preview;
+        let preview = this.preview.body;
         if (this.settings && this.settings.parameters) {
             // Replace any placeholders in the template with our custom values.
             const values: { placeholder: string, value: string }[] = Object.keys(this.settings.parameters)

--- a/ng-ncc-app/src/app/services/call.service.ts
+++ b/ng-ncc-app/src/app/services/call.service.ts
@@ -99,7 +99,7 @@ export class CallService {
             )
                 .pipe(
                     map(data => {
-                        return { call: <ICRMServiceRequest>data[0], account: <IAccountDetails>data[1] };
+                        return { call: <ICRMServiceRequest>data[0], account: data[1] };
                     })
                 )
                 .subscribe(

--- a/ng-ncc-app/src/app/services/dpa.service.ts
+++ b/ng-ncc-app/src/app/services/dpa.service.ts
@@ -34,7 +34,7 @@ export class DPAService {
                 map((data: IAccountDetails) => {
                     if (data) {
                         this._tenancy = {
-                            rent_balance: -parseFloat(data.currentBalance, 10),
+                            rent_balance: -data.currentBalance,
                             rent_amount: data.rent,
                             tenancy_reference: data.tagReferenceNumber
                         };


### PR DESCRIPTION
![screenshot - 17_10_2018 14_24_35](https://user-images.githubusercontent.com/41298289/47089515-e9e5ce00-d218-11e8-8b09-7fe7c6ec3397.png)

![screenshot - 17_10_2018 14_30_08](https://user-images.githubusercontent.com/41298289/47089647-30d3c380-d219-11e8-82bf-7c538274c0a1.png)

The Blank email template could not be sent because of a placeholder in the template's subject. This adds fields for such placeholders.