### PR TITLE
Comms warning fix.

### DIFF
--- a/ng-ncc-app/src/app/components/notify-template-preview/notify-template-preview.component.html
+++ b/ng-ncc-app/src/app/components/notify-template-preview/notify-template-preview.component.html
@@ -12,7 +12,7 @@
     <div class="govuk-grid-column-one-half">
 
         <!-- A warning for agents not to enter any sensitive data. -->
-        <app-warning>
+        <app-warning *ngIf="hasPlaceholders()">
             Don't put sensitive or personal information here without passing DPA questions,
             or you may breach GDPR.
         </app-warning>


### PR DESCRIPTION
The warning should only be displayed if there are placeholders.