### PR TITLE
Correcting (the appearance of) the back link on the Caller Identification page.

### DIFF
--- a/ng-ncc-app/src/app/pages/identify/identify.component.ts
+++ b/ng-ncc-app/src/app/pages/identify/identify.component.ts
@@ -43,9 +43,11 @@ export class PageIdentifyComponent implements OnInit, OnDestroy {
             this.addressSelected(this.Call.getTenancy());
         }
 
-        // Enable the app's back link.
-        this.BackLink.enable();
-        this.BackLink.setTarget('/log-call');
+        // Enable the app's back link if there's no current caller.
+        if (!this.Call.hasCaller()) {
+            this.BackLink.enable();
+            this.BackLink.setTarget('/log-call');
+        }
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
It should only be displayed if a caller has not been selected (anonymous or otherwise).