### PR TITLE
Store the initial interaction ID from a note.

### DIFF
--- a/ng-ncc-app/src/app/API/NCCAPI/ncc-api.service.ts
+++ b/ng-ncc-app/src/app/API/NCCAPI/ncc-api.service.ts
@@ -18,6 +18,7 @@ import { NOTES } from '../../constants/notes.constant';
 import { CALL_REASON } from '../../constants/call-reason.constant';
 import { COMMS } from '../../constants/comms.constant';
 import { PAYMENT_STATUS } from '../../constants/payment-status.constant';
+import { CallService } from '../../services/call.service';
 
 @Injectable({
     providedIn: 'root'
@@ -277,31 +278,7 @@ export class NCCAPIService {
     /**
      * Begins processing a payment through Paris.
      */
-    beginPayment(call_id: string, crm_contact_id: string, tenancy_id: string, payment_reference: string, call_reason_id,
-        ticket_number: string, amount: number) {
-
-        // We have to obtain an interaction ID before redirecting to Paris.
-        // We can get one by posting an automatic note, where a payment status if given.
-        const parameters = {
-            PaymentStatus: PAYMENT_STATUS.INITIATED
-        };
-
-        return this.createAutomaticNote(
-            call_id, ticket_number, tenancy_id, call_reason_id, crm_contact_id, 'Beginning payment',
-            { PaymentStatus: PAYMENT_STATUS.INITIATED }
-        )
-            .pipe(
-                map((data: IJSONResponse) => {
-                    return this._redirectToParis(data.response.NCCInteraction.interactionId, payment_reference, amount);
-                })
-            );
-    }
-
-    /**
-     *
-     */
-    private _redirectToParis(interaction_id: string, payment_reference: string, amount: number) {
-
+    getPaymentURL(interaction_id: string, payment_reference: string, amount: number): Observable<string> {
         const return_data = [
             interaction_id,
             'sshetty', // username
@@ -321,7 +298,7 @@ export class NCCAPIService {
         };
 
         const url = `https://hackney.paris-epayments.co.uk/paymentstest/sales/launchinternet.aspx?${this._buildQueryString(parameters)}`;
-        return url;
+        return of(url);
     }
 
     /**

--- a/ng-ncc-app/src/app/pages/payment/make/payment-make.component.ts
+++ b/ng-ncc-app/src/app/pages/payment/make/payment-make.component.ts
@@ -48,6 +48,9 @@ export class PagePaymentMakeComponent implements OnInit {
         }
     }
 
+    /**
+     *
+     */
     constructor(private injectorObj: Injector) {
         this.Call = this.injectorObj.get(CallService);
         this.NCCAPI = this.injectorObj.get(NCCAPIService);
@@ -55,6 +58,9 @@ export class PagePaymentMakeComponent implements OnInit {
         this.PageTitle = this.injectorObj.get(PageTitleService);
     }
 
+    /**
+     *
+     */
     ngOnInit() {
         this.PageTitle.set(PAGES.RENT_PAYMENT.label);
         this.Call.getAccount()
@@ -81,15 +87,7 @@ export class PagePaymentMakeComponent implements OnInit {
      * A callback for if the user confirms making a payment.
      */
     answeredYes() {
-        this.NCCAPI.beginPayment(
-            this.Call.getCallID(),
-            this.Call.getCaller().getContactID(),
-            this.Call.getTenancyReference(),
-            this.Call.getPaymentReference(),
-            this.Call.getCallNature().call_reason.id,
-            this.Call.getTicketNumber(),
-            this.getNumericAmount()
-        )
+        this.NCCAPI.getPaymentURL(this.Call, this.getNumericAmount())
             .pipe(take(1))
             .subscribe((url: string) => {
                 // For some reason the URL is returned as an encoded string (which makes a BIG difference).

--- a/ng-ncc-app/src/app/pages/payment/make/payment-make.component.ts
+++ b/ng-ncc-app/src/app/pages/payment/make/payment-make.component.ts
@@ -87,7 +87,7 @@ export class PagePaymentMakeComponent implements OnInit {
      * A callback for if the user confirms making a payment.
      */
     answeredYes() {
-        this.NCCAPI.getPaymentURL(this.Call, this.getNumericAmount())
+        this.NCCAPI.getPaymentURL(this.Call.getInteractionID(), this.Call.getPaymentReference(), this.getNumericAmount())
             .pipe(take(1))
             .subscribe((url: string) => {
                 // For some reason the URL is returned as an encoded string (which makes a BIG difference).

--- a/ng-ncc-app/src/app/services/call.service.ts
+++ b/ng-ncc-app/src/app/services/call.service.ts
@@ -221,6 +221,9 @@ export class CallService {
         return null !== this.tenancy;
     }
 
+    /**
+     *
+     */
     _buildTenantsList() {
         this.tenants = this.tenancy.results.map((row) => {
             return {
@@ -230,8 +233,18 @@ export class CallService {
         });
     }
 
+    /**
+     *
+     */
     getTenants() {
         return this.tenants;
+    }
+
+    /**
+     *
+     */
+    getInteractionID(): string {
+        return this.interaction_id;
     }
 
     /**

--- a/ng-ncc-app/src/app/services/call.service.ts
+++ b/ng-ncc-app/src/app/services/call.service.ts
@@ -251,11 +251,15 @@ export class CallService {
      * Reset the call to a new state.
      */
     reset() {
+        this.account = null;
         this.caller = null;
         this.call_nature = null;
         this.call_id = null;
-        this.ticket_number = null;
+        this.interaction_id = null;
         this.tenancy = null;
+        this.tenants = null;
+        this.ticket_number = null;
+
         console.log('Call was reset.');
     }
 

--- a/ng-ncc-app/src/app/services/call.service.ts
+++ b/ng-ncc-app/src/app/services/call.service.ts
@@ -4,7 +4,9 @@ import { Observable, forkJoin, of, from } from 'rxjs';
 
 import { CALL_REASON } from '../constants/call-reason.constant';
 import { ICaller } from '../interfaces/caller';
+import { IJSONResponse } from '../interfaces/json-response';
 import { ILogCallSelection } from '../interfaces/log-call-selection';
+import { INCCNote } from '../interfaces/ncc-note';
 import { NCCAPIService } from '../API/NCCAPI/ncc-api.service';
 import { HackneyAPIService } from '../API/HackneyAPI/hackney-api.service';
 import { ManageATenancyAPIService } from '../API/ManageATenancyAPI/manageatenancy-api.service';
@@ -35,6 +37,7 @@ export class CallService {
     private caller: ICaller;
     private call_nature: ILogCallSelection;
     private call_id: string;
+    private interaction_id: string;
     private tenancy: IAddressSearchGroupedResult;
     private tenants: { [propKey: string]: string }[];
     private ticket_number: string;
@@ -155,7 +158,13 @@ export class CallService {
     createCallerNote() {
         if (this.call_id) {
             const name = this.caller.isAnonymous() ? 'anonymous' : this.caller.getName();
-            this.recordAutomaticNote(`Caller identified as ${name}.`);
+            this.recordAutomaticNote(`Caller identified as ${name}.`)
+                .subscribe((data: INCCNote) => {
+                    // Store the interaction ID from this note for later use (i.e. when and if making a payment.)
+                    // Making a payment via Paris requires an interaction ID, and since we're creating this note we can obtain one from it.
+                    this.interaction_id = data.interactionId;
+                    console.log('Interaction ID is', this.interaction_id);
+                });
         }
     }
 
@@ -186,7 +195,7 @@ export class CallService {
     setCallNature(selection: ILogCallSelection) {
         this.call_nature = selection;
         if (this.call_id) {
-            this.recordAutomaticNote(`Additional call reason.`);
+            this.recordAutomaticNote(`Additional call reason.`).subscribe();
         }
     }
 
@@ -250,13 +259,14 @@ export class CallService {
             this.call_nature.call_reason.id,
             this.caller.getContactID(),
             note_content
-        ).pipe(take(1));
+        ).pipe(take(1))
+            .pipe(map((data: IJSONResponse[]) => data[0].response.NCCInteraction));
     }
 
     /**
      * Record an automatic note against the call.
      */
-    recordAutomaticNote(note_content: string) {
+    recordAutomaticNote(note_content: string): Observable<any> {
         note_content = this._formatNoteContent(note_content);
 
         return forkJoin(
@@ -274,7 +284,8 @@ export class CallService {
             // Action Diary note...
             this.recordActionDiaryNote(note_content)
 
-        ).pipe(take(1)).subscribe();
+        ).pipe(take(1))
+            .pipe(map((data: IJSONResponse[]) => data[0].response.NCCInteraction));
         // This allows us to retrieve the Observables results just once.
     }
 


### PR DESCRIPTION
Instead of creating a new note to obtain an interaction ID (required for making a payment), one is obtained from the note created when a caller is identified.