### PR TITLE
Correcting an issue on the successful transaction page.

### DIFF
--- a/ng-ncc-app/src/app/pages/transaction/success/success.component.html
+++ b/ng-ncc-app/src/app/pages/transaction/success/success.component.html
@@ -29,12 +29,6 @@
     <app-value-list-label>Administration charge</app-value-list-label>
     <app-value-list-value>{{ data.administrationcharge | currency:'GBP' }}</app-value-list-value>
 
-    <app-value-list-label>Processed?</app-value-list-label>
-    <app-value-list-value>{{ wasSuccessful() ? 'Yes' : 'No' }}</app-value-list-value>
-
-    <app-value-list-label>Error message</app-value-list-label>
-    <app-value-list-value>{{ data.error }}</app-value-list-value>
-
 </app-value-list>
 
 <form (submit)="sendMessage($event)" *ngIf="!_error">


### PR DESCRIPTION
When sending the receipt, the actual message was sent but the resulting dialogue did not appear. This might have had something to do with an invalid reference on the page.