### PR TITLE
Notes for non-tenants should be recorded against the anonymous user.

### DIFF
--- a/ng-ncc-app/src/app/classes/anonymous-caller.class.ts
+++ b/ng-ncc-app/src/app/classes/anonymous-caller.class.ts
@@ -12,7 +12,17 @@ export class AnonymousCaller implements ICaller {
         return true;
     }
 
+    /**
+     * Returns the caller's CRM contact ID.
+     */
     getContactID(): string {
+        return environment.anonymousUserID;
+    }
+
+    /**
+     * Returns the the CRM contact ID to use for recording notes.
+     */
+    getContactIDForNotes(): string {
         return environment.anonymousUserID;
     }
 

--- a/ng-ncc-app/src/app/classes/identified-caller.class.ts
+++ b/ng-ncc-app/src/app/classes/identified-caller.class.ts
@@ -106,6 +106,13 @@ export class IdentifiedCaller implements ICaller {
     }
 
     /**
+     * Returns the the CRM contact ID to use for recording notes.
+     */
+    getContactIDForNotes(): string | null {
+        return this._details.crmContactId;
+    }
+
+    /**
      * Returns TRUE if the caller has no email address[es].
      */
     hasNoEmailAddresses(): boolean {

--- a/ng-ncc-app/src/app/classes/non-tenant-caller.class.ts
+++ b/ng-ncc-app/src/app/classes/non-tenant-caller.class.ts
@@ -12,6 +12,13 @@ export class NonTenantCaller extends AnonymousCaller {
         this._crm_contact_id = crm_contact_id;
     }
 
+    getName(): string {
+        return 'Non-tenant';
+    }
+
+    /**
+     * Returns the caller's CRM contact ID.
+     */
     getContactID(): string {
         return this._crm_contact_id;
     }

--- a/ng-ncc-app/src/app/components/note-form/note-form.component.html
+++ b/ng-ncc-app/src/app/components/note-form/note-form.component.html
@@ -33,7 +33,7 @@
                     [(ngModel)]="comment" [disabled]="saving" rows="4" aria-describedby="more-detail-hint"></textarea>
 
                 <!-- View notes link. -->
-                <a class="govuk-body-s note-form__view-notes" [routerLink]="page_defs.VIEW_NOTES.route">
+                <a class="govuk-body-s note-form__view-notes" [routerLink]="page_defs.VIEW_NOTES.route" *ngIf="!isCallerAnonymous()">
                     View notes
                 </a>
             </div>

--- a/ng-ncc-app/src/app/interfaces/caller.ts
+++ b/ng-ncc-app/src/app/interfaces/caller.ts
@@ -9,6 +9,7 @@ export interface ICaller {
     getName(): string;
     getTelephoneNumbers(): string[];
     getContactID(): string | null;
+    getContactIDForNotes(): string | null;
     getEmailAddresses(): string[];
     getPostalAddress(): ContactAddress;
     hasNoTelephoneNumbers(): boolean;

--- a/ng-ncc-app/src/app/services/call.service.ts
+++ b/ng-ncc-app/src/app/services/call.service.ts
@@ -157,7 +157,7 @@ export class CallService {
                             ticket_number: this.ticket_number,
                             call_reason_id: this.call_nature.call_reason.id,
                             other_reason: this.call_nature.other_reason,
-                            crm_contact_id: this.caller.getContactID(),
+                            crm_contact_id: this.caller.getContactIDForNotes(),
                             tenancy_reference: this.account.tagReferenceNumber
                         };
                         this.Notes.enable(this.caller.getName(), settings);


### PR DESCRIPTION
These notes are being created, but for some reason don't show up in the list of notes on the View Notes page.