### PR TITLE
Correcting the comms page route.

### DIFF
--- a/ng-ncc-app/src/app/app-routing.module.ts
+++ b/ng-ncc-app/src/app/app-routing.module.ts
@@ -199,7 +199,7 @@ export const AppRoutes: Routes = [
         canActivate: [AuthGuard],
         resolve: {
             caller: CallerResolver,
-            call_nature: CallNatureResolver
+            // call_nature: CallNatureResolver
         }
     },
     {


### PR DESCRIPTION
As the call type and reason aren't selected until the end of the call, they're no longer required to access the comms page.