### PR TITLE
Redirect to the authentication link if no code was provided.

### DIFF
--- a/ng-ncc-app/src/app/auth/auth.guard.ts
+++ b/ng-ncc-app/src/app/auth/auth.guard.ts
@@ -41,14 +41,20 @@ export class AuthGuard implements CanActivate {
 
                         return outcome;
                     }));
-        } else if (environment.disable.authentication) {
-            // Attempt to bypass authentication, which won't work if the respective environment variable isn't set.
-            const outcome = this.Auth.bypass();
-            this._setViewOnlyMode(isViewOnly);
-            return outcome;
+        } else {
+            if (environment.disable.authentication) {
+                // Attempt to bypass authentication, which won't work if the respective environment variable isn't set.
+                const outcome = this.Auth.bypass();
+                this._setViewOnlyMode(isViewOnly);
+                return outcome;
+            } else {
+                // No authentication code: try redirecting to the authentication URL.
+                window.location.href = environment.authenticationLink;
+                return;
+            }
         }
 
-        // No code or logged in user.
+        // No logged in user.
         this.router.navigate([`/${PAGES.TRY_AGAIN.route}`]);
         return false;
     }

--- a/ng-ncc-app/src/app/pages/rent/communications/communications.component.ts
+++ b/ng-ncc-app/src/app/pages/rent/communications/communications.component.ts
@@ -44,14 +44,10 @@ export class PageRentCommunicationsComponent extends PageCommunications implemen
             .subscribe((account: IAccountDetails) => { this.account_details = account; });
 
         // Obtain tenancy agreeement details.
-        this.tenancyReference = this.Call.getTenancyReference();
-        this.NCCAPI.getTenancyAgreementDetails(this.tenancyReference)
+        this.NCCAPI.getTenancyAgreementDetails(this.account_details.tagReferenceNumber)
             .pipe(takeUntil(this._destroyed$))
             .subscribe((details: ITenancyAgreementDetails) => {
                 this.tenancyDetails = details;
-
-                // Automatically generate a statement.
-                this.refreshStatement();
             });
     }
 

--- a/ng-ncc-app/src/app/pages/rent/communications/communications.component.ts
+++ b/ng-ncc-app/src/app/pages/rent/communications/communications.component.ts
@@ -7,9 +7,10 @@ import { PAGES } from '../../../constants/pages.constant';
 import { CommsOption } from '../../../classes/comms-option.class';
 import { PageCommunications } from '../../abstract/communications';
 import { DPAService } from '../../../services/dpa.service';
-import { NextPaymentService } from '../../../services/next-payment.service';
+import { NCCAPIService } from '../../../API/NCCAPI/ncc-api.service';
 import { IAccountDetails } from '../../../interfaces/account-details';
 import { IAddressSearchGroupedResult } from '../../../interfaces/address-search-grouped-result';
+import { ITenancyAgreementDetails } from '../../../interfaces/tenancy-agreement-details';
 
 @Component({
     selector: 'app-rent-communications',
@@ -18,14 +19,15 @@ import { IAddressSearchGroupedResult } from '../../../interfaces/address-search-
 })
 export class PageRentCommunicationsComponent extends PageCommunications implements OnInit {
 
-    NextPayment: NextPaymentService;
+    NCCAPI: NCCAPIService;
     tenancy: IAddressSearchGroupedResult;
+    tenancyDetails: ITenancyAgreementDetails;
     is_non_tenant: boolean;
     is_identified: boolean;
 
     constructor(@Inject(LOCALE_ID) private locale: string, private injector: Injector) {
         super(injector);
-        this.NextPayment = this.injector.get(NextPaymentService);
+        this.NCCAPI = this.injector.get(NCCAPIService);
     }
 
     /**
@@ -40,6 +42,17 @@ export class PageRentCommunicationsComponent extends PageCommunications implemen
         this.Call.getAccount()
             .pipe(takeUntil(this._destroyed$))
             .subscribe((account: IAccountDetails) => { this.account_details = account; });
+
+        // Obtain tenancy agreeement details.
+        this.tenancyReference = this.Call.getTenancyReference();
+        this.NCCAPI.getTenancyAgreementDetails(this.tenancyReference)
+            .pipe(takeUntil(this._destroyed$))
+            .subscribe((details: ITenancyAgreementDetails) => {
+                this.tenancyDetails = details;
+
+                // Automatically generate a statement.
+                this.refreshStatement();
+            });
     }
 
     /**
@@ -77,10 +90,9 @@ export class PageRentCommunicationsComponent extends PageCommunications implemen
     updatePreview() {
         super.updatePreview();
         if (this.isSensitiveTemplateSelected() && this.preview) {
-            const next_payment = this.NextPayment.calculate(this.account_details);
             this.preview.parameters = {
                 'Tenancy reference': this.account_details.tagReferenceNumber,
-                'Rent balance': formatCurrency(next_payment, this.locale, '£'),
+                'Rent balance': formatCurrency(this.tenancyDetails.displayBalance, this.locale, '£'),
                 'Rent amount': formatCurrency(this.account_details.rent, this.locale, '£')
             };
         }


### PR DESCRIPTION
This was introduced to prevent "try again" errors when refreshing the page.