### PR TITLE
Format Action Diary and UH note dates correctly.

### DIFF
--- a/ng-ncc-app/package.json
+++ b/ng-ncc-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-ncc-app",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/ng-ncc-app/src/app/common/API/NCCAPI/ncc-api.service.ts
+++ b/ng-ncc-app/src/app/common/API/NCCAPI/ncc-api.service.ts
@@ -237,8 +237,8 @@ export class NCCAPIService {
                             break;
                         default:
                             date = moment(row.createdOn);
-                            row.createdOn = date.format('DD/MM/YYYY HH:mm');
                     }
+                    row.createdOn = date.format('DD/MM/YYYY HH:mm');
 
                     // We also want the date formatted differently for sorting purposes.
                     row.createdOnSort = date.format('YYYYMMDDHHmmss');


### PR DESCRIPTION
They were shown with seconds before, so making them consistent.