### PR TITLE
Feature/ncc 823

### DIFF
--- a/ng-ncc-app/.vscode/launch.json
+++ b/ng-ncc-app/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "name": "Launch Chrome against localhost, with sourcemaps",
+          "type": "chrome",
+          "request": "launch",
+          "url": "http://localhost:4200",
+          "sourceMaps": true,
+          "webRoot": "${workspaceRoot}"
+      },
+      {
+          "name": "Attach to Chrome, with sourcemaps",
+          "type": "chrome",
+          "request": "attach",
+          "port": 9222,
+          "sourceMaps": true,
+          "webRoot": "${workspaceRoot}"
+      }
+  ]
+}

--- a/ng-ncc-app/src/app/common/API/NCCAPI/ncc-api.service.ts
+++ b/ng-ncc-app/src/app/common/API/NCCAPI/ncc-api.service.ts
@@ -125,6 +125,7 @@ export class NCCAPIService {
             ticket_number: response.ticketNumber,
             call_reason_id: response.callReasonId,
             other_reason: response.otherReason,
+            existing_repair_contractor_reason: response.existingRepairContractorReason,
             crm_contact_id: response.contactId,
             content: responseMessage,
             tenancy_reference: response.tenancyReference,
@@ -145,6 +146,7 @@ export class NCCAPIService {
         const parameters = Object.assign({
             CallReasonId: settings.call_reason_id || '',
             OtherReason: settings.other_reason,
+            ExistingRepairContractorReason: settings.existing_repair_contractor_reason,
             'ServiceRequest.Id': settings.call_id,
             'ServiceRequest.TicketNumber': settings.ticket_number,
             'ServiceRequest.ContactId': settings.crm_contact_id,

--- a/ng-ncc-app/src/app/common/API/NCCAPI/ncc-api.service.ts
+++ b/ng-ncc-app/src/app/common/API/NCCAPI/ncc-api.service.ts
@@ -125,7 +125,7 @@ export class NCCAPIService {
             ticket_number: response.ticketNumber,
             call_reason_id: response.callReasonId,
             other_reason: response.otherReason,
-            existing_repair_contractor_reason: response.existingRepairContractorReason,
+            existing_repair_contractor_reason: null,
             crm_contact_id: response.contactId,
             content: responseMessage,
             tenancy_reference: response.tenancyReference,

--- a/ng-ncc-app/src/app/common/constants/call-reason.constant.ts
+++ b/ng-ncc-app/src/app/common/constants/call-reason.constant.ts
@@ -1,3 +1,4 @@
 export const CALL_REASON = {
-    OTHER: '0'
+    OTHER: '0',
+    EXISTING_REPAIR_CONTRACTOR: 'Existing Repair: Contractor'
 };

--- a/ng-ncc-app/src/app/common/interfaces/add-note-parameters.ts
+++ b/ng-ncc-app/src/app/common/interfaces/add-note-parameters.ts
@@ -4,6 +4,7 @@ export interface IAddNoteParameters {
     ticket_number: string;
     call_reason_id: string;
     other_reason: string;
+    existing_repair_contractor_reason: string;
     crm_contact_id: string;
     tenancy_reference: string | null;
     agent_name: string | null;

--- a/ng-ncc-app/src/app/common/interfaces/log-call-selection.ts
+++ b/ng-ncc-app/src/app/common/interfaces/log-call-selection.ts
@@ -8,4 +8,5 @@ export class ILogCallSelection {
     call_type: LogCallType | null;
     call_reason: LogCallReason | null;
     other_reason?: string | null;
+    existing_repair_contractor_reason?: string | null;
 }

--- a/ng-ncc-app/src/app/common/interfaces/notes-settings.ts
+++ b/ng-ncc-app/src/app/common/interfaces/notes-settings.ts
@@ -3,6 +3,7 @@ export interface INotesSettings {
     ticket_number: string;
     call_reason_id: string;
     other_reason: string | null;
+    existing_repair_contractor_reason: string | null;
     crm_contact_id: string;
     content: string;
     calltransferred?: boolean;

--- a/ng-ncc-app/src/app/common/services/call.service.ts
+++ b/ng-ncc-app/src/app/common/services/call.service.ts
@@ -251,7 +251,7 @@ export class CallService {
     private _getCallNatureAsText(): string {
         const call_type = this.call_nature.call_type.label;
         const call_reason = this.call_nature.other_reason ? `Other (${this.call_nature.other_reason})` :
-            this.call_nature.existing_repair_contractor_reason ? `Existing Repair: Contractor (${this.call_nature.existing_repair_contractor_reason})` :
+            this.call_nature.existing_repair_contractor_reason ? `${CALL_REASON.EXISTING_REPAIR_CONTRACTOR} (${this.call_nature.existing_repair_contractor_reason})` :
             this.call_nature.call_reason.label;
         return `${call_type} - ${call_reason}`;
     }
@@ -374,7 +374,7 @@ export class CallService {
     private _formatNoteContent(note_content: string): string {
         if (CALL_REASON.OTHER === this.call_nature.call_reason.id) {
             note_content = `Other: ${this.call_nature.other_reason}\n${note_content}`;
-        } else if (this.call_nature.call_reason.label === 'Existing Repair: Contractor') {
+        } else if (this.call_nature.call_reason.label === CALL_REASON.EXISTING_REPAIR_CONTRACTOR) {
             note_content = `${this.call_nature.existing_repair_contractor_reason}\n${note_content}`
         }
 

--- a/ng-ncc-app/src/app/common/services/call.service.ts
+++ b/ng-ncc-app/src/app/common/services/call.service.ts
@@ -190,6 +190,7 @@ export class CallService {
                             ticket_number: this.ticket_number,
                             call_reason_id: null, // TODO this.call_nature.call_reason.id,
                             other_reason: null, // TODO this.call_nature.other_reason,
+                            existing_repair_contractor_reason: null, // TODO this.call_nature.existing_repair_contractor_reason,
                             crm_contact_id: this.caller.getContactID(),
                             tenancy_reference: tenancy_reference
                         };
@@ -250,6 +251,7 @@ export class CallService {
     private _getCallNatureAsText(): string {
         const call_type = this.call_nature.call_type.label;
         const call_reason = this.call_nature.other_reason ? `Other (${this.call_nature.other_reason})` :
+            this.call_nature.existing_repair_contractor_reason ? `Existing Repair: Contractor (${this.call_nature.existing_repair_contractor_reason})` :
             this.call_nature.call_reason.label;
         return `${call_type} - ${call_reason}`;
     }
@@ -372,6 +374,8 @@ export class CallService {
     private _formatNoteContent(note_content: string): string {
         if (CALL_REASON.OTHER === this.call_nature.call_reason.id) {
             note_content = `Other: ${this.call_nature.other_reason}\n${note_content}`;
+        } else if (this.call_nature.call_reason.label === 'Existing Repair: Contractor') {
+            note_content = `${this.call_nature.existing_repair_contractor_reason}\n${note_content}`
         }
 
         return note_content;

--- a/ng-ncc-app/src/app/common/services/notes.service.ts
+++ b/ng-ncc-app/src/app/common/services/notes.service.ts
@@ -142,6 +142,7 @@ export class NotesService {
                 tenancy_reference: this._settings.tenancy_reference,
                 call_reason_id: call_nature ? call_nature.call_reason.id : null,
                 other_reason: call_nature ? call_nature.other_reason : null,
+                existing_repair_contractor_reason: call_nature ? call_nature.existing_repair_contractor_reason : null,
                 crm_contact_id: this._settings.crm_contact_id,
                 content: this._formatNoteContent(note_content, call_nature)
             }),
@@ -179,6 +180,7 @@ export class NotesService {
                 ticket_number: this._settings.ticket_number,
                 call_reason_id: call_nature.call_reason.id,
                 other_reason: call_nature.other_reason,
+                existing_repair_contractor_reason: call_nature.existing_repair_contractor_reason,
                 crm_contact_id: this._settings.crm_contact_id,
                 content: this._formatNoteContent(note_content, call_nature),
                 calltransferred: transferred,
@@ -236,6 +238,7 @@ export class NotesService {
                 tenancy_reference: this._settings.tenancy_reference,
                 call_reason_id: null,
                 other_reason: null,
+                existing_repair_contractor_reason: null,
                 crm_contact_id: this._settings.crm_contact_id,
                 content: note_content,
                 parameters: {
@@ -279,6 +282,7 @@ export class NotesService {
                 tenancy_reference: this._settings.tenancy_reference,
                 call_reason_id: call_nature.call_reason.id,
                 other_reason: call_nature.other_reason,
+                existing_repair_contractor_reason: call_nature.existing_repair_contractor_reason,
                 crm_contact_id: this._settings.crm_contact_id,
                 content: noteMessage
             }, details),
@@ -338,6 +342,8 @@ export class NotesService {
     private _formatNoteContent(note_content: string, call_nature: ILogCallSelection = null): string {
         if (call_nature && call_nature.other_reason) {
             note_content = `Other: ${call_nature.other_reason}\n${note_content}`;
+        } else if (call_nature && call_nature.existing_repair_contractor_reason) {
+            note_content = `${call_nature.existing_repair_contractor_reason}\n${note_content}`
         }
 
         return note_content;
@@ -382,6 +388,7 @@ export class NotesService {
                     call_nature.call_reason.label +
                     ' (' +
                     call_nature.other_reason +
+                    call_nature.existing_repair_contractor_reason + 
                     ')'
                 );
         }

--- a/ng-ncc-app/src/app/main/components/call-nature/call-nature-dialogue/call-nature-dialogue.component.html
+++ b/ng-ncc-app/src/app/main/components/call-nature/call-nature-dialogue/call-nature-dialogue.component.html
@@ -35,6 +35,16 @@
                                     <input class="govuk-checkboxes__input" id="call-reason-{{ reason.id }}" name="call_reason" type="checkbox" [(checklist)]="selectedReasonIds" (ngModelChange)="updateSelection()" [checklistValue]="reason.id" (checklistChange)="_mapSelectedCallReasonsToListOfReasons()">
                                     <label class="govuk-label govuk-checkboxes__label" for="call-reason-{{ reason.id }}">{{ reason.label }}</label>
                                 </div>
+                                <!-- A text field for entering additional text for "Existing Repair: Contractor" (in the event of "Existing Repair: Contractor" being selected). -->
+                                <div class="govuk-form-group govuk-!-margin-left-8 govuk-!-margin-top-1" *ngIf="isExistingRepairContractorReasonSelected() && reason.id === optionExistingRepairContractor.id">
+                                    <label class="govuk-label govuk-!-font-weight-bold govuk-visually-hidden" for="call_reason_existing_repair_contractor">
+                                        Specify the call reason:
+                                    </label>
+                                    <input type="text" class="govuk-input govuk-input--width-20" id="call_reason_existing_repair_contractor" name="call_reason_existing_repair_contractor"
+                                        placeholder="Specify the call reason" maxlength="50"
+                                        #existingRepairContractorReasonField
+                                        [(ngModel)]="existingRepairContractorReasonText[optionExistingRepairContractor.id]" (ngModelChange)="updateSelection()">
+                                </div>
 
                                 <!-- Secondary labels. -->
 

--- a/ng-ncc-app/src/app/main/components/call-nature/call-nature-dialogue/call-nature-dialogue.component.ts
+++ b/ng-ncc-app/src/app/main/components/call-nature/call-nature-dialogue/call-nature-dialogue.component.ts
@@ -36,6 +36,7 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
 
     // A reference to the text field used for entering "other" call reason text.
     @ViewChild('otherReasonField') otherReasonField: ElementRef;
+    @ViewChild('existingRepairContractorReasonField') existingRepairContractorReasonField: ElementRef;
 
     // A private Subject used to unsubscribe from subscriptions, to avoid memory leaks.
     private _destroyed$ = new Subject<void>();
@@ -45,6 +46,8 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
     callTypes: LogCallType[];
     error: boolean;
     optionOther: LogCallReason;
+    optionExistingRepairContractor: LogCallReason;
+    existingRepairContractorReasonText: { [propKey: string]: string}; // contains additional text for call-type specific "Existing Repair: Contractor" reasons.
     otherReasonText: { [propKey: string]: string }; // contains additional text for call-type specific "other" reasons.
     otherReasonIds: string[];
     saving: boolean;
@@ -117,6 +120,7 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
         this.selectedReasons = [];
         this.selectedReasonIds = [];
         this.otherReasonText = {};
+        this.existingRepairContractorReasonText = {};
     }
 
     /**
@@ -165,8 +169,11 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
             // because of the below method.
             this._separateOther(reasons);
 
-            reasons.sort(this._sortCallReasons);
+            // Set optionExistingRepairContractor option as variable to add text box in UI
+            this.optionExistingRepairContractor = reasons.find(x => x.label === 'Existing Repair: Contractor');
 
+            reasons.sort(this._sortCallReasons);
+            
             return reasons;
         }
     }
@@ -220,6 +227,9 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
         if (this.isOtherReasonSelected()) {
             this._focusOtherReason();
         }
+        if (this.isExistingRepairContractorReasonSelected()) {
+            this._focusExistingRepairContractorReason();
+        }
     }
 
     /**
@@ -251,11 +261,27 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
     }
 
     /**
+     * Returns TRUE if "Existing Repair: Contractor" is selected as the call reason.
+     */
+    isExistingRepairContractorReasonSelected(): boolean {
+        return this.optionExistingRepairContractor !== undefined ? this.isReasonSelected(this.optionExistingRepairContractor) : false;
+    }
+
+    /**
      * Set the focus on the other reason field.
      */
     private _focusOtherReason() {
         if (this.otherReasonField) {
             this.otherReasonField.nativeElement.focus();
+        }
+    }
+
+    /**
+     * Set the focus on the existing repair contractor text field
+     */
+    private _focusExistingRepairContractorReason() {
+        if (this.existingRepairContractorReasonField) {
+            this.existingRepairContractorReasonField.nativeElement.focus();
         }
     }
 
@@ -306,6 +332,7 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
 
         const notes = this.selectedReasons.map((reason) => {
             const otherReasonText = this.otherReasonText[reason.callReasonId] ? this.otherReasonText[reason.callReasonId] : null;
+            const existingRepairContractorReasonText = this.existingRepairContractorReasonText[reason.callReasonId] ? this.existingRepairContractorReasonText[reason.callReasonId] : null;
             return {
                 call_type: {
                     id: reason.callTypeId,
@@ -315,7 +342,8 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
                     id: reason.callReasonId,
                     label: reason.callReasonLabel
                 },
-                other_reason: otherReasonText
+                other_reason: otherReasonText,
+                existing_repair_contractor_reason: existingRepairContractorReasonText
             };
         });
 

--- a/ng-ncc-app/src/app/main/components/call-nature/call-nature-dialogue/call-nature-dialogue.component.ts
+++ b/ng-ncc-app/src/app/main/components/call-nature/call-nature-dialogue/call-nature-dialogue.component.ts
@@ -170,7 +170,7 @@ export class CallNatureDialogueComponent extends ConfirmDialogueComponent
             this._separateOther(reasons);
 
             // Set optionExistingRepairContractor option as variable to add text box in UI
-            this.optionExistingRepairContractor = reasons.find(x => x.label === 'Existing Repair: Contractor');
+            this.optionExistingRepairContractor = reasons.find(x => x.label === CALL_REASON.EXISTING_REPAIR_CONTRACTOR);
 
             reasons.sort(this._sortCallReasons);
             

--- a/ng-ncc-app/src/app/main/pages/add-notes/add-notes.component.ts
+++ b/ng-ncc-app/src/app/main/pages/add-notes/add-notes.component.ts
@@ -60,6 +60,7 @@ export class PageAddNotesComponent extends PageNotes implements OnInit, OnDestro
             ticket_number: this.previous_call.ticketnumber,
             call_reason_id: this.previous_call.callreasonId,
             other_reason: null,
+            existing_repair_contractor_reason: null,
             crm_contact_id: this.previous_call.contactid,
             tenancy_reference: this.previous_call.housingref
         };


### PR DESCRIPTION
Add a text field to the "Existing Repair: Contractor" checkbox to allow further information to be entered.

This is a bit of a hack as the Existing Repair: Contractor option is pulled for an API so if its text gets updated this will stop working. I've saved the text in the CALL_REASON const, so that at least if it does change we can just update it in one place.